### PR TITLE
Removed Automatic Whitespace Removal from Haml Filter

### DIFF
--- a/autoload/zencoding.vim
+++ b/autoload/zencoding.vim
@@ -353,8 +353,6 @@ function! s:zen_toString_haml(settings, current, type, inline, filters, itemno, 
     endif
     if stridx(','.settings.html.empty_elements.',', ','.current.name.',') != -1 && len(current.value) == 0
       let str .= "/"
-    elseif stridx(','.settings.html.block_elements.',', ','.current.name.',') != -1 && (len(current.child) == 0 && len(current.value) == 0)
-      let str .= '<'
     endif
 
     let inner = ''


### PR DESCRIPTION
While this is technically valid Haml, I don't see it ever being ideal in practice.

It's fair to say that Haml itself would feel incomplete if it did not provide this feature, but who uses it?
Since Haml's configuration makes it trivial to optimize it's output for readability or efficiency, I've never felt the need to fiddle with it's whitespace handling on such a low level and I suspect hardly anyone that uses it does.

Also, since an empty tag generated by ZenCoding is unlikely to stay empty long, it doesn't make sense to treat them as though they will.
