### PR TITLE
Use command 'identify' (if supported) to get the size of a local image

### DIFF
--- a/autoload/zencoding/util.vim
+++ b/autoload/zencoding/util.vim
@@ -242,5 +242,5 @@ function! zencoding#util#imageSizeWithImageMagick(fn)
 endfunction
 
 function! zencoding#util#isImageMagickInstalled()
-    return !(empty(system('command identify')))
+    return executable('identify')
 endfunction


### PR DESCRIPTION
- For large files the amount of time needed is considerably lower
- Command 'identify' is provided by ImageMagick
