### PR TITLE
Added less support

### DIFF
--- a/autoload/zencoding.vim
+++ b/autoload/zencoding.vim
@@ -1152,6 +1152,9 @@ let s:zen_settings = {
 \    'scss': {
 \        'extends': 'css',
 \    },
+\    'less': {
+\        'extends': 'css',
+\    },
 \    'html': {
 \        'snippets': {
 \            'cc:ie6': "<!--[if lte IE 6]>\n\t${child}|\n<![endif]-->",


### PR DESCRIPTION
I added less support for the zen coding,

I choose this way over setting the simply setting the filetype to css is because of the code coloring.
