### PR TITLE
The zencoding folder also needs to be copied to ~/.vim/autoload

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -25,6 +25,7 @@ or:
     cd zencoding-vim
     cp plugin/zencoding.vim ~/.vim/plugin/
     cp autoload/zencoding.vim ~/.vim/autoload/
+    cp -a autoload/zencoding ~/.vim/autoload/
 
 
 ## Quick Tutorial


### PR DESCRIPTION
When copying the plugin manually to ~/.vim, it is important to also copy the autoload/zencoding folder.
