### PR TITLE
fix the 'href' attribute missing when make an anchor from URL use <c-y>a/A

### DIFF
--- a/autoload/zencoding.vim
+++ b/autoload/zencoding.vim
@@ -573,6 +573,10 @@ function! zencoding#anchorizeURL(flag)
   if a:flag == 0
     let a = zencoding#lang#html#parseTag('<a>')
     let a.attr.href = url
+    " add attribute name 'href' to a.ttrs_order
+    " modify begin
+    call add(a.attrs_order,'href')
+    " modify end
     let a.value = '{' . title . '}'
     let expand = zencoding#toString(a, rtype, 0, [])
     let expand = substitute(expand, '\${cursor}', '', 'g')


### PR DESCRIPTION
this is a bug fix,my vim version is v7.3.547,os is ubuntu 13.04,zencoding version is the latest code of master on github.

when I use &lt;c-y&gt;a/A to make an anchor from URL,the tag 'a' do not have 'href' attribute.that is,your website http://mattn.kaoriya.net/ will become '&lt;a&gt;Big Sky&lt;/a&gt;' instead of '&lt;a  href="http://mattn.kaoriya.net/" &gt;Big Sky&lt;/a&gt;'.

I don't familiar with the sourcecode of zen-coding and not very good at vimscript,so I only read the relate functions :
    function! zencoding#anchorizeURL(flag)
    function! zencoding#toString(...)
        in /autoload/zencoding.vim,
    function! zencoding#lang#html#toString(settings, current, type, inline,
      filters, itemno, indent) 
        in /autoload/zencoding/lang/html.vim,
    function! zencoding#util#unique(arr)
        in autoload/zencoding/util.vim.

I find the reason why 'href' attribute is missed is because the attrs_order array of a is  empty,this variable is not assigned,I assign the variable in the function zencoding#anchorizeURL(flag) in /autoload/zencoding.vim,it works,the tag is correct.

but I do not know whether is this a common problem or the best way to
fix the bug,please pay some attention to the &lt;c-y&gt;a/A problem.

This is my first time to fork project and push code,I'm not sure whether it is the proper way to do this to report the bug.

By the way,I like this plugin,it's really cool.

I'm not very good at English,hope you can know what I mean.
