### PR TITLE
allow detection of filetype if multiple filetypes are declared

### DIFF
--- a/autoload/zencoding.vim
+++ b/autoload/zencoding.vim
@@ -260,9 +260,15 @@ endfunction
 function! zencoding#getFileType(...)
   let flg = get(a:000, 0, 0)
   let type = &ft
-  if zencoding#lang#exists(&ft)
-    let type = &ft
-  else
+  let found_type = ''
+  for partial_type in split(type, '\.')
+    if zencoding#lang#exists(partial_type)
+      let found_type = 'true'
+      let type = partial_type
+      break
+    endif
+  endfor
+  if found_type != 'true'
     let base = zencoding#getBaseType(type)
     if base != ""
       if flg


### PR DESCRIPTION
not sure if this is the best approach (finding the first suitable file type and using that), but I imagine there's a lot more involved if we wanted to really support multiple file types (eg: html + css), so this at least works with a single type.

Also, I'm not sure if there's a better way to define the found_type variable (not sure if vim has a boolean type). Feel free to correct this code as you see fit.
