### PR TITLE
Fix numbering on nested multiplication

### DIFF
--- a/autoload/emmet.vim
+++ b/autoload/emmet.vim
@@ -169,7 +169,7 @@ function! emmet#toString(...)
   let rtype = emmet#lang#exists(type) ? type : 'html'
   while itemno < current.multiplier
     if len(current.name)
-      if group_itemno != 0
+      if current.multiplier == 1
         let inner = emmet#lang#{rtype}#toString(s:emmet_settings, current, type, inline, filters, group_itemno, indent)
       else
         let inner = emmet#lang#{rtype}#toString(s:emmet_settings, current, type, inline, filters, itemno, indent)


### PR DESCRIPTION
If an element is being multiplied, its number should reflect the repeating of that element, not the group it belongs in.

I'm not sure if this is the best way to go about fixing this bug. If there is a better way, please let me know.
# Example case

Output was generated using mattn/emmet-vim@9791571, Vim 7.3 in Cygwin. Behavior also observed in Vim on Arch Linux.
<br>
#### Input

`.outer$*3>.inner$*2`
<br>
#### Expected output

``` html
<div class="outer1">
    <div class="inner1"></div>
    <div class="inner2"></div>
</div>
<div class="outer2">
    <div class="inner1"></div>
    <div class="inner2"></div>
</div>
<div class="outer3">
    <div class="inner1"></div>
    <div class="inner2"></div>
</div>
```

<br>
#### Observed output

``` html
<div class="outer1">
    <div class="inner1"></div>
    <div class="inner2"></div>
</div>
<div class="outer2">
    <div class="inner2"></div>
    <div class="inner2"></div>
</div>
<div class="outer3">
    <div class="inner3"></div>
    <div class="inner3"></div>
</div>
```

<br>
#### Output after change

See "Expected output" above.
