### PR TITLE
Adding instructions for using Vundle

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -17,6 +17,10 @@ To install using pathogen.vim:
 
     cd ~/.vim/bundle
     unzip /path/to/emmet-vim.zip
+    
+To install using [Vundle|https://github.com/gmarik/vundle]:
+    #add this line to your .vimrc file
+    Bundle "mattn/emmet-vim"
 
 To checkout the source from repository:
 


### PR DESCRIPTION
Vundle is like pathogen but just an eeeensy bit better.
I use it instead because all I need to version is my .vimrc file.  
