### PR TITLE
Pathogen defacto standard is to use 'git clone'. Moreover, the 'unzip /p...

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -16,7 +16,7 @@ which provides support for expanding abbreviations similar to
 To install using pathogen.vim:
 
     cd ~/.vim/bundle
-    git clone git@github.com:mattn/emmet-vim.git
+    git clone https://github.com/mattn/emmet-vim.git
     
 To install using [Vundle|https://github.com/gmarik/vundle]:
     #add this line to your .vimrc file
@@ -25,11 +25,11 @@ To install using [Vundle|https://github.com/gmarik/vundle]:
 To checkout the source from repository:
 
     cd ~/.vim/bundle
-    git clone git@github.com:mattn/emmet-vim.git
+    git clone https://github.com/mattn/emmet-vim.git
 
 or:
 
-    git clone git@github.com:mattn/emmet-vim.git
+    git clone https://github.com/mattn/emmet-vim.git
     cd emmet-vim
     cp plugin/emmet.vim ~/.vim/plugin/
     cp autoload/emmet.vim ~/.vim/autoload/


### PR DESCRIPTION
...ath/to/emmet-vim.zip' command does not work because a parent directory (e.g. emmit-vim) needs to be created within the ~/.vim/bundle dir for vim to pickup the plugin correctly. Lastly, use the SSH url as it is the cloning default standard.
