### PR TITLE
Fix comment filter

### DIFF
--- a/autoload/emmet/lang/html.vim
+++ b/autoload/emmet/lang/html.vim
@@ -470,7 +470,7 @@ function! emmet#lang#html#toString(settings, current, type, inline, filters, ite
     let str .= "</" . current_name . ">"
   endif
   if len(comment) > 0
-    let str .= "\n<!-- /" . comment . " -->"
+    let str .= "<!-- /" . comment . " -->"
   endif
   if len(current_name) > 0 && current.multiplier > 0 || stridx(','.settings.html.block_elements.',', ','.current_name.',') != -1
     let str .= "\n"


### PR DESCRIPTION
When comment filter enabled, the comment was being added to the begging and the end. ex: 

```
<!-- .class-one --><div class="class-one">
</div>
<!-- .class-one -->
```

Only need the one comment at the end.  That also doesnt need to be on a new line.  Same line as the ending tag. So it becomes

```
<div class="class-one">
</div><!-- .class-one -->
```
