### PR TITLE
change shortcut description

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -47,7 +47,7 @@ Type ("\_" is the cursor position):
 
     html:5_
 
-Then type "\<c-y\>," (Ctrl and y, then ','), you should see:
+Then type "\<c-y\>," ('Ctrl + y', then ','), you should see:
 
 ```html
 <!DOCTYPE HTML>


### PR DESCRIPTION
Hi guys,

I had the same issue as some guys here: #148 . The shortcut just did not seem to work.
Thanks to the discussion in the issue emmet-vim was working as intended. Think we should update the docs a bit to make it clearer that we have to wait a bit until we press ','.

My attempt to make it clearer is attached.

Thanks for the great plugin
Andreas
