### PR TITLE
Document g:user_emmet_leader_key's trailing ','.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -47,7 +47,7 @@ Type ("\_" is the cursor position):
 
     html:5_
 
-Then type "\<c-y\>," ('Ctrl + y', then ','), you should see:
+Then type `<c-y>,` (<kbd>Ctrl</kbd><kbd>y</kbd><kbd>,</kbd>), and you should see:
 
 ```html
 <!DOCTYPE HTML>
@@ -84,10 +84,14 @@ autocmd FileType html,css EmmetInstall
 ```
 
 ## Redefine trigger key
+To remap the default `<C-Y>` leader:
 
 ```vim
 let g:user_emmet_leader_key='<C-Z>'
 ```
+
+Note that the trailing `,` still needs to be entered, so the new keymap would be `<C-Z>,`.
+
 ## Adding custom snippets
 If you have installed the [web-api](https://github.com/mattn/webapi-vim) for **emmet-vim** you can also add your own snippets using a custom **snippets.json** file.
 

--- a/doc/emmet.txt
+++ b/doc/emmet.txt
@@ -334,7 +334,10 @@ CUSTOMIZE                                                      *emmet-customize*
 >
   let g:user_emmet_leader_key = '<c-y>'
 <
-  Or if you prefer to map for each actions, then you set each variables.
+  Note that a trailing ',' must be entered, so the resultant keymap is
+  '<c-y>,'.
+  
+  If you prefer to map for each actions, then you set each variables.
 
     'user_emmet_expandabbr_key'
     'user_emmet_expandword_key'


### PR DESCRIPTION
Add some text to `README.mkd` and `doc/emmet.txt` to clarify that any keymap specified with `g:user_emmet_leader_key` must be followed by a `,`.
