### PR TITLE
Changed 'parenthesis' setting to 'attribute_style' setting

### DIFF
--- a/autoload/emmet.vim
+++ b/autoload/emmet.vim
@@ -1671,7 +1671,7 @@ let s:emmet_settings = {
 \                    ."\t%body\n"
 \                    ."\t\t${child}|\n",
 \        },
-\        'parentheses': '{}',
+\        'attribute_style': 'hash',
 \    },
 \    'slim': {
 \        'indentation': '  ',


### PR DESCRIPTION
I removed your "parenthesis" setting and changed it to an "attribute_style" setting which defaults to the HAML "Hash Style" attributes but can be set to utilize the "HTML Style" attributes. I'm not 100% sure if the verbiage makes sense so would be open to feedback from others. 

Also, I've tackled what I thought were the correct parts of the plugin but I'm not 100% sure I've got everything covered. Specifically, I don't have a complete understanding of what is supposed to happen here: https://github.com/conraddecker/emmet-vim/blob/437cd920044185b956d6ff6b8e9f4abbc1744bbd/autoload/emmet/lang/haml.vim#L35. 

When will `type(Val) == 2`? In addition, I've searched through the code base and can't find any other reference to `function('emmet#types#true')`

Lastly, I'm noticing a couple errors in my local environment when I try to expand certain inputs. 
This `nav>ul>li` expands without a problem but when I attempt to expand `td[rowspan=2 colspan=3 title]` I get the following errors:

![screenshot 2014-07-17 09 52 21](https://cloud.githubusercontent.com/assets/771695/3613695/206b9bee-0dba-11e4-94af-47b40e9024b0.png)

I'm pretty certain those are a result of the changes that I made primarily because it only happens when there are attributes that need to expand but I'm not 100% certain what it is that's causing the problem. Would certainly be open to some pointers to get it cleared up.

Let me know what you think. 

Thanks!
