### PR TITLE
Small fix related to VIM Tip #436

### DIFF
--- a/plugin/emmet.vim
+++ b/plugin/emmet.vim
@@ -147,7 +147,7 @@ function! s:install_plugin(mode, buffer)
       let key = g:user_emmet_leader_key . item.key
     endif
     if len(maparg(key, item.mode)) == 0
-      exe item.mode . 'map ' . buffer . ' <unique> ' . key . ' <plug>(' . item.plug . ')'
+      exe item.mode . 'map ' . buffer . ' <unique> ' . key . ' <c-g>u<plug>(' . item.plug . ')'
     endif
   endfor
 endfunction


### PR DESCRIPTION
http://vim.wikia.com/wiki/Recover_from_accidental_Ctrl-U

Suppose you do the following:

div.foo.bar.baz<c-y>,

This will be expanded to <div clas="foo bar baz"></div>

Then you realize that you wanted yyy instead of baz. You press ESC and
u and notice that you don't have your original string in the undo log
(div.foo.bar.baz).

This patch fixes this behaviour.
