### PR TITLE
Fix Vundle instructions

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -20,8 +20,8 @@ To install using pathogen.vim:
     
 To install using [Vundle](https://github.com/gmarik/vundle):
 
-    # add this line to your .vimrc file
-    Bundle "mattn/emmet-vim"
+    " add this line to your .vimrc file
+    Plugin 'mattn/emmet-vim'
 
 To checkout the source from repository:
 


### PR DESCRIPTION
- Fix syntax to work in .vimrc
- The Bundle command is being renamed to Plugin (although Bundle still
  works for now)
