### PR TITLE
use two dollars to escape $

### DIFF
--- a/doc/emmet.txt
+++ b/doc/emmet.txt
@@ -420,8 +420,8 @@ CUSTOMIZE                                                      *emmet-customize*
   \  },
   \  'javascript' : {
   \    'snippets' : {
-  \      'jq' : "$(function() {\n\t${cursor}${child}\n});",
-  \      'jq:each' : "$.each(arr, function(index, item)\n\t${child}\n});",
+  \      'jq' : "\\$(function() {\n\t${cursor}${child}\n});",
+  \      'jq:each' : "\\$.each(arr, function(index, item)\n\t${child}\n});",
   \      'fn' : "(function() {\n\t${cursor}\n})();",
   \      'tm' : "setTimeout(function() {\n\t${cursor}\n}, 100);",
   \    },


### PR DESCRIPTION
I just find that the setting example in doc is wrong.

Single `$` expand to digital number. Like 'jq' expand to

```
1(function() {

});
```
