### PR TITLE
Do not hardcode a default indentation setting

### DIFF
--- a/autoload/emmet.vim
+++ b/autoload/emmet.vim
@@ -929,7 +929,6 @@ let s:emmet_settings = {
 \      'lang': "en",
 \      'locale': "en-US",
 \      'charset': "UTF-8",
-\      'indentation': "\t",
 \      'newline': "\n",
 \      'use_selection': 0,
 \    },


### PR DESCRIPTION
Change 2a8f0e094d3fae2ef081db873af3c3835f271280 hardcoded a value for `s:emmet_settings.variables.indentation`, which incorrectly overrides the logic in `emmet#getIndentation()` that respects a user's indentation settings in the absence of an explicit emmet indentation config setting.

**Repro**

1.  Start vim.
2.  `set expandtab`
3.  `set shiftwidth=2`
4.  `set tabstop=8`
5.  Create a new file, e.g. `:e index.html`
6.  Expand `html:5`

**Actual results**

Indentation is all tabs.

**Expected results**

The indentation should be two spaces per indent level.

