### PR TITLE
Jade: remove extra "/" after empty elements expansion

### DIFF
--- a/autoload/emmet/lang/jade.vim
+++ b/autoload/emmet/lang/jade.vim
@@ -72,9 +72,6 @@ function! emmet#lang#jade#toString(settings, current, type, inline, filters, ite
         let str .= '(' . tmp . ')'
       end
     endif
-    if stridx(','.settings.html.empty_elements.',', ','.current_name.',') != -1 && len(current.value) == 0
-      let str .= '/'
-    endif
 
     let inner = ''
     if len(current.value) > 0


### PR DESCRIPTION
For instance, `img` should be expanded to `img(src="", alt="")` rather than `img(src="", alt="")/`
(See #280)