### PR TITLE
fix jsx type check to support multi file types

### DIFF
--- a/autoload/emmet/lang/html.vim
+++ b/autoload/emmet/lang/html.vim
@@ -501,7 +501,7 @@ function! emmet#lang#html#toString(settings, current, type, inline, filters, ite
       if has_key(an, attr)
         let attr = an[attr]
       endif
-      if type == 'jsx' && Val =~ '^{.*}$'
+      if emmet#isExtends(type, 'jsx') && Val =~ '^{.*}$'
         let str .= ' ' . attr . '=' . Val
       else
         let str .= ' ' . attr . '=' . q . Val . q


### PR DESCRIPTION
It is quite common to use .js for for JSX files, and [vim-jsx](https://github.com/mxw/vim-jsx) will set the filetype to javascript.jsx.

Fix to support such use case. Thanks.