### PR TITLE
add option to anchorizeUrl which works offline

### DIFF
--- a/TUTORIAL
+++ b/TUTORIAL
@@ -160,6 +160,9 @@ Tutorial for Emmet.vim
   ---------------------
   <a href="http://www.google.com/">Google</a>
   ---------------------
+  This requires internet connection, if you just want the template, put
+    let g:emmet#anchorizeURLDoNotQuery = 1
+  in your .vimrc or init.vim.
 
 13. Make some quoted text from a URL
 
@@ -175,6 +178,7 @@ Tutorial for Emmet.vim
   	<cite>http://github.com/</cite>
   </blockquote>
   ---------------------
+  `g:emmet#anchorizeURLDoNotQuery` works for this one too.
 
 14. Installing emmet.vim for the language you are using:
 

--- a/autoload/emmet.vim
+++ b/autoload/emmet.vim
@@ -854,12 +854,20 @@ function! emmet#anchorizeURL(flag) abort
     return ''
   endif
 
-  let mx = '.*<title[^>]*>\s*\zs\([^<]\+\)\ze\s*<\/title[^>]*>.*'
-  let content = emmet#util#getContentFromURL(url)
-  let content = substitute(content, '\r', '', 'g')
-  let content = substitute(content, '[ \n]\+', ' ', 'g')
-  let content = substitute(content, '<!--.\{-}-->', '', 'g')
-  let title = matchstr(content, mx)
+  if !exists("g:emmet#anchorizeURLDoNotQuery")
+    let g:emmet#anchorizeURLDoNotQuery = 0
+  endif
+  if g:emmet#anchorizeURLDoNotQuery
+    let content = ''
+    let title = ''
+  else
+    let mx = '.*<title[^>]*>\s*\zs\([^<]\+\)\ze\s*<\/title[^>]*>.*'
+    let content = emmet#util#getContentFromURL(url)
+    let content = substitute(content, '\r', '', 'g')
+    let content = substitute(content, '[ \n]\+', ' ', 'g')
+    let content = substitute(content, '<!--.\{-}-->', '', 'g')
+    let title = matchstr(content, mx)
+  endif
 
   let type = emmet#getFileType()
   let rtype = emmet#lang#exists(type) ? type : 'html'
@@ -893,6 +901,19 @@ function! emmet#anchorizeURL(flag) abort
   let indent = substitute(getline('.'), '^\(\s*\).*', '\1', '')
   let expand = substitute(expand, "\n", "\n" . indent, 'g')
   call emmet#util#setContent(block, expand)
+  " position the cursor so that user can start typing immediately
+  if g:emmet#anchorizeURLDoNotQuery
+    if &filetype ==# 'markdown'
+      execute "normal! l"
+      startinsert
+    elseif a:flag ==# 0
+      execute "normal! f>l"
+      startinsert
+    else
+      execute "normal! /<p>\<CR>:noh\<CR>3ldt<"
+      startinsert
+    endif
+  endif
   return ''
 endfunction
 


### PR DESCRIPTION
`<C-y>a` and `<C-y>A` will hang for a long time in some situations (e.g. China's network -> google.com), or sometimes the user may only want the boilerplate and fill the title themselves. This variable  `g:emmet#anchorizeURLDoNotQuery` makes this explicit.