### PR TITLE
Fix #382 - Multiple class name expansion with Elm

### DIFF
--- a/autoload/emmet/lang/elm.vim
+++ b/autoload/emmet/lang/elm.vim
@@ -133,7 +133,7 @@ function! emmet#lang#elm#toString(settings, current, type, inline, filters, item
         if attr ==# 'id' && len(valtmp) > 0
           let tmp .=', id "' . Val . '"'
         elseif attr ==# 'class' && len(valtmp) > 0
-          let tmp .= ', class "' . substitute(Val, ' ', '.', 'g') . '"'
+          let tmp .= ', class "' . substitute(Val, '\.', ' ', 'g') . '"'
         else
           let tmp .= ', ' . attr . ' "' . Val . '"'
         endif


### PR DESCRIPTION
This change makes the multiple class name expansion work correctly in Elm.

```
div.one.two.three
```

Becomes
```
    div [ class "one two three" ] []
```

Previously you would get
```
    div [ class "one.two.three" ] []
```
https://github.com/mattn/emmet-vim/issues/382