### PR TITLE
Match js and jsx to apply className

### DIFF
--- a/autoload/emmet.vim
+++ b/autoload/emmet.vim
@@ -1977,6 +1977,11 @@ let s:emmet_settings = {
 \        'attribute_name': {'class': 'className', 'for': 'htmlFor'},
 \        'empty_element_suffix': ' />',
 \    },
+\    'js': {
+\        'extends': 'html',
+\        'attribute_name': {'class': 'className', 'for': 'htmlFor'},
+\        'empty_element_suffix': ' />',
+\    },
 \    'xslt': {
 \        'extends': 'xsl',
 \    },


### PR DESCRIPTION
"The distinction between .js and .jsx files was useful before Babel, but it’s not that useful anymore.

There are other syntax extensions (e.g. Flow). What would you call a JS file that uses Flow? .flow.js? What about JSX file that uses Flow? .flow.jsx? What about some other experimental syntax? .flow.stage-1.jsx?

Most editors are configurable so you can tell them to use a JSX-capable syntax scheme for .js files. Since JSX (or Flow) are strict supersets of JS, I don’t see this as an issue."
https://github.com/facebookincubator/create-react-app/issues/87#issuecomment-234627904