### PR TITLE
fix a broken markdown heading

### DIFF
--- a/TUTORIAL.mkd
+++ b/TUTORIAL.mkd
@@ -146,7 +146,7 @@ And then type '<c-y>j' in there again.
   </div>
 ```
 
-##Toggle Comment
+## Toggle Comment
 
 Move cursor inside the block
 


### PR DESCRIPTION
no space between heading indicator and text