### PR TITLE
fix: fix undefined variable: ftype

### DIFF
--- a/autoload/emmet.vim
+++ b/autoload/emmet.vim
@@ -115,7 +115,7 @@ function! emmet#isExpandable() abort
   let part = matchstr(line, '\(\S.*\)$')
   let type = emmet#getFileType()
   let rtype = emmet#lang#type(type)
-  let part = emmet#lang#{ftype}#findTokens(part)
+  let part = emmet#lang#{rtype}#findTokens(part)
   return len(part) > 0
 endfunction
 


### PR DESCRIPTION
use `imap <expr> <tab> emmet#expandAbbrIntelligent('\<tab>')` while get error , undefined variable: ftype, I find [this change](https://github.com/mattn/emmet-vim/commit/f8fc806a61cd3692836598000a5731e5ec4992e4#diff-88ee7622f49bacf8a1d8ba95ee919310L122) lead to this