### PR TITLE
Fix updateTag() boolean attribute

### DIFF
--- a/autoload/emmet/lang/html.vim
+++ b/autoload/emmet/lang/html.vim
@@ -720,11 +720,11 @@ endfunction
 
 function! emmet#lang#html#parseTag(tag) abort
   let current = emmet#newNode()
-  let mx = '<\([a-zA-Z][a-zA-Z0-9]*\)\(\%(\s[a-zA-Z][a-zA-Z0-9]\+=\%([^"'' \t]\+\|"[^"]\{-}"\|''[^'']\{-}''\)\s*\)*\)\(/\{0,1}\)>'
+  let mx = '<\([a-zA-Z][a-zA-Z0-9]*\)\(\%(\s[a-zA-Z][a-zA-Z0-9]\+=\?\%([^"'' \t]\+\|"[^"]\{-}"\|''[^'']\{-}''\)\s*\)*\)\(/\{0,1}\)>'
   let match = matchstr(a:tag, mx)
   let current.name = substitute(match, mx, '\1', 'i')
   let attrs = substitute(match, mx, '\2', 'i')
-  let mx = '\([a-zA-Z0-9]\+\)=\%(\([^"'' \t]\+\)\|"\([^"]\{-}\)"\|''\([^'']\{-}\)''\)'
+  let mx = '\([a-zA-Z0-9]\+\)\(\(=[^"'' \t]\+\)\|="\([^"]\{-}\)"\|=''\([^'']\{-}\)''\)\?'
   while len(attrs) > 0
     let match = matchstr(attrs, mx)
     if len(match) == 0
@@ -732,8 +732,12 @@ function! emmet#lang#html#parseTag(tag) abort
     endif
     let attr_match = matchlist(match, mx)
     let name = attr_match[1]
-    let value = len(attr_match[2]) ? attr_match[2] : attr_match[3]
-    let current.attr[name] = value
+    if len(attr_match[2])
+      let Val = len(attr_match[3]) ? attr_match[3] : attr_match[4]
+    else
+      let Val = function('emmet#types#true')
+    endif
+    let current.attr[name] = Val
     let current.attrs_order += [name]
     let attrs = attrs[stridx(attrs, match) + len(match):]
   endwhile

--- a/unittest.vim
+++ b/unittest.vim
@@ -681,6 +681,10 @@ finish
           'query': "<h$$$$\\<c-y>u.global\\<cr>$$$$3></h3>",
           'result': "<h3 class=\"global\"></h3>",
         },
+        {
+          'query': "<button$$$$\\<c-y>u.btn\\<cr>$$$$ disabled></button>",
+          'result': "<button class=\"btn\" disabled></button>",
+        },
       ],
     },
     {


### PR DESCRIPTION
`updateTag()` doesn't work with HTML tag with boolean attribute.

**Steps to reproduce**

1. `<button disabled></button>` 
2. `<C-y>u`
3. `.btn<CR>`
4. Result: `</button>`

![5B779D4D-420B-45B9-A0D1-E340C47EA935](https://user-images.githubusercontent.com/6082303/80919856-3109c480-8da7-11ea-9abd-961b86a29f52.png)
