### PR TITLE
Support sass type in syntax name

### DIFF
--- a/autoload/emmet.vim
+++ b/autoload/emmet.vim
@@ -392,6 +392,8 @@ function! emmet#getFileType(...) abort
 
   if type =~? '^css'
     let type = 'css'
+  elseif type =~? '^sass'
+    let type = 'sass'
   elseif type =~? '^html'
     let type = 'html'
   elseif type =~? '^jsx'


### PR DESCRIPTION
Hi, thanks for this awesome plugin. 
Vue components can have sass in it, like `<style lang="sass">...`. [leafOfTree/vim-vue-plugin](https://github.com/leafOfTree/vim-vue-plugin) tries to enable sass snippets in Vue by syntax context. So it will be great to support sass type in syntax name.