### PR TITLE
Add meta tag for responsiviness

### DIFF
--- a/autoload/emmet.vim
+++ b/autoload/emmet.vim
@@ -371,13 +371,13 @@ endfunction
 
 function! emmet#getFileType(...) abort
   let flg = get(a:000, 0, 0)
-  
+
   if has_key(s:emmet_settings, &filetype)
     let type = &filetype
     if emmet#getResource(type, 'ignore_embeded_filetype', 0)
-      return type 
+      return type
     endif
-  endif 
+  endif
 
   let pos = emmet#util#getcurpos()
   let type = synIDattr(synID(max([pos[1], 1]), max([pos[2], 1]), 1), 'name')
@@ -1737,6 +1737,7 @@ let s:emmet_settings = {
 \                    ."<html lang=\"${lang}\">\n"
 \                    ."<head>\n"
 \                    ."\t<meta charset=\"${charset}\">\n"
+\                    ."\t<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
 \                    ."\t<title></title>\n"
 \                    ."</head>\n"
 \                    ."<body>\n\t${child}|\n</body>\n"


### PR DESCRIPTION
The usual `html:5_` snippet does not have the meta tag with the contents
`name="viewport" content="width=device-width, initial-scale=1"`, which
allows the website to be responsive.

This commit also cleans some white spaces.