### PR TITLE
Support CSS in JS syntax

### DIFF
--- a/autoload/emmet.vim
+++ b/autoload/emmet.vim
@@ -404,6 +404,8 @@ function! emmet#getFileType(...) abort
     let type = 'typescript'
   elseif type =~? '^xml'
     let type = 'xml'
+  elseif type == 'styledEmmetAbbreviation'
+    let type = 'styled'
   else
     let types = split(&filetype, '\.')
     for part in types
@@ -1678,6 +1680,9 @@ let s:emmet_settings = {
 \        'extends': 'css',
 \    },
 \    'css.drupal': {
+\        'extends': 'css',
+\    },
+\    'styled': {
 \        'extends': 'css',
 \    },
 \    'html': {

--- a/autoload/emmet/lang/css.vim
+++ b/autoload/emmet/lang/css.vim
@@ -23,7 +23,7 @@ function! emmet#lang#css#parseIntoTree(abbr, type) abort
   " emmet
   let tokens = split(abbr, '+\ze[^+)!]')
   let block = emmet#util#searchRegion('{', '}')
-  if abbr !~# '^@' && emmet#getBaseType(type) ==# 'css' && type !=# 'sass' && block[0] ==# [0,0] && block[1] ==# [0,0]
+  if abbr !~# '^@' && emmet#getBaseType(type) ==# 'css' && type !=# 'sass' && type !=# 'styled' && block[0] ==# [0,0] && block[1] ==# [0,0]
     let current = emmet#newNode()
     let current.snippet = substitute(abbr, '\s\+$', '', '') . " {\n" . indent . "${cursor}\n}"
     let current.name = ''

--- a/syntax/javascript.vim
+++ b/syntax/javascript.vim
@@ -1,0 +1,3 @@
+" Register `styledEmmetAbbreviation` syntax in `styledDefinition` region defined in
+" https://github.com/styled-components/vim-styled-components.
+syntax match styledEmmetAbbreviation "[a-z0-9#+!%]\+" containedin=styledDefinition contained

--- a/syntax/javascriptreact.vim
+++ b/syntax/javascriptreact.vim
@@ -1,0 +1,1 @@
+runtime syntax/javascript.vim

--- a/syntax/typescript.vim
+++ b/syntax/typescript.vim
@@ -1,0 +1,1 @@
+runtime syntax/javascript.vim

--- a/syntax/typescriptreact.vim
+++ b/syntax/typescriptreact.vim
@@ -1,0 +1,1 @@
+runtime syntax/javascript.vim


### PR DESCRIPTION
Related issue: https://github.com/mattn/emmet-vim/issues/427

It adds `styledEmmetAbbreviation` syntax to `styledDefinition` region which is defined in [this syntax plugin](https://github.com/styled-components/vim-styled-components).
Then, defines the syntax as `styled` type which extends `css`.
Since CSS in JS does not require `{` region `}` to write properties, it adds `type !=# 'styled'` condition to `emmet#lang#css#parseIntoTree` function, as `sass` type does.

Although it requires https://github.com/styled-components/vim-styled-components to work, it should not harm environments where the plugin is not installed, because `syntax match styledEmmetAbbreviation "[a-z0-9#+!%]\+" containedin=styledDefinition contained` does nothing if `styledDefinition` is not defined.

Thank you!