### PR TITLE
Use first <title> in document when anchorizing URLs

### DIFF
--- a/autoload/emmet.vim
+++ b/autoload/emmet.vim
@@ -865,7 +865,7 @@ function! emmet#anchorizeURL(flag) abort
     return ''
   endif
 
-  let mx = '.*<title[^>]*>\s*\zs\([^<]\+\)\ze\s*<\/title[^>]*>.*'
+  let mx = '<title[^>]*>\s*\zs\([^<]\+\)\ze\s*<\/title[^>]*>'
   let content = emmet#util#getContentFromURL(url)
   let content = substitute(content, '\r', '', 'g')
   let content = substitute(content, '[ \n]\+', ' ', 'g')


### PR DESCRIPTION
Fix an issue where anchorizeURL used the last `<title>` found in a document, instead of the first:

```html
<html>
<head>
<title>THE TITLE WE WANT</title>
</head>
<body>
  <svg>
    <title>An irrelevant accessibility title</title>
    ...
  </svg>
</body>
</html>
```

Example URL (at time of writing): `https://blog.getbootstrap.com/2020/06/16/bootstrap-5-alpha/`