### PR TITLE
Update README.mkd

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -3,7 +3,7 @@
 
 [![Build Status](https://travis-ci.org/mattn/emmet-vim.svg?branch=master)](https://travis-ci.org/mattn/emmet-vim)
 
-[emmet-vim](http://mattn.github.com/emmet-vim) is a vim plug-in
+[emmet-vim](https://mattn.github.io/emmet-vim/) is a vim plug-in
 which provides support for expanding abbreviations similar to
 [emmet](http://emmet.io/).
 
@@ -132,7 +132,7 @@ You can change the **path** to your **snippets_custom.json** according to your p
 
 ### emmet.vim:
 
-* <http://mattn.github.com/emmet-vim>
+* <https://mattn.github.io/emmet-vim/>
 
 ### development repository:
 


### PR DESCRIPTION
Fixes broken github pages links. github.com urls for github pages sites are deprecated as of earlier this year and should be replaced with github.io