### PR TITLE
fix bug in len() invalid 

### DIFF
--- a/autoload/emmet.vim
+++ b/autoload/emmet.vim
@@ -430,7 +430,7 @@ function! emmet#getFileType(...) abort
     endfor
   endif
 
-  return len(type) == 0 ? 'html' : type
+  return empty(type) ? 'html' : type
 endfunction
 
 function! emmet#getDollarExprs(expand) abort


### PR DESCRIPTION
in files with double extension type: "hola.txt.md" it generated an error it is because you were passing a null to len() that detects if the file does not have an extension `len(type)==0`