### PR TITLE
fix: replace deprecated treesitter call

### DIFF
--- a/lua/emmet_utils.lua
+++ b/lua/emmet_utils.lua
@@ -1,8 +1,7 @@
 local M = {}
 
 M.get_node_at_cursor = function()
-	local ts_utils = require("nvim-treesitter.ts_utils")
-	local node = ts_utils.get_node_at_cursor()
+	local node = vim.treesitter.get_node()
 	if not node then
 		return nil
 	end


### PR DESCRIPTION
Current error when using emmet-vim.

```
Error detected while processing function CtrlK[6]..emmet#expandAbbr[1]..emmet#getFileType:
line   11:
E5108: Error executing lua ...osx/.local/share/nvim/lazy/emmet-vim/lua/emmet_utils.lua:4: module 'nvim-treesitter.ts_utils' not found:
        no field package.preload['nvim-treesitter.ts_utils']
        cache_loader: module 'nvim-treesitter.ts_utils' not found
        cache_loader_lib: module 'nvim-treesitter.ts_utils' not found
        no file './nvim-treesitter/ts_utils.lua'
        no file '/usr/share/luajit-2.1/nvim-treesitter/ts_utils.lua'
        no file '/usr/local/share/lua/5.1/nvim-treesitter/ts_utils.lua'
        no file '/usr/local/share/lua/5.1/nvim-treesitter/ts_utils/init.lua'
        no file '/usr/share/lua/5.1/nvim-treesitter/ts_utils.lua'
        no file '/usr/share/lua/5.1/nvim-treesitter/ts_utils/init.lua'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/telescope.nvim/share/lua/5.1/nvim-treesitter/ts_utils.lua'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/telescope.nvim/share/lua/5.1/nvim-treesitter/ts_utils/init.lua'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/nvim-dap-python/share/lua/5.1/nvim-treesitter/ts_utils.lua'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/nvim-dap-python/share/lua/5.1/nvim-treesitter/ts_utils/init.lua'
        no file './nvim-treesitter/ts_utils.so'
        no file '/usr/local/lib/lua/5.1/nvim-treesitter/ts_utils.so'
        no file '/usr/lib/lua/5.1/nvim-treesitter/ts_utils.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/telescope.nvim/lib/lua/5.1/nvim-treesitter/ts_utils.so'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/telescope.nvim/lib64/lua/5.1/nvim-treesitter/ts_utils.so'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/nvim-dap-python/lib/lua/5.1/nvim-treesitter/ts_utils.so'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/nvim-dap-python/lib64/lua/5.1/nvim-treesitter/ts_utils.so'
        no file './nvim-treesitter.so'
        no file '/usr/local/lib/lua/5.1/nvim-treesitter.so'
        no file '/usr/lib/lua/5.1/nvim-treesitter.so'
        no file '/usr/local/lib/lua/5.1/loadall.so'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/telescope.nvim/lib/lua/5.1/nvim-treesitter.so'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/telescope.nvim/lib64/lua/5.1/nvim-treesitter.so'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/nvim-dap-python/lib/lua/5.1/nvim-treesitter.so'
        no file '/home/dosx/.local/share/nvim/lazy-rocks/nvim-dap-python/lib64/lua/5.1/nvim-treesitter.so'
stack traceback:
        [C]: in function 'require'
        ...osx/.local/share/nvim/lazy/emmet-vim/lua/emmet_utils.lua:4: in function 'get_node_at_cursor'
        [string "luaeval()"]:1: in main chunk
```

Replaced deprecated call [vim.treesitter.get_node_at_cursor()](https://neovim.io/doc/user/deprecated/#vim.treesitter.get_node_at_cursor()) with `vim.treesitter.get_node()`.